### PR TITLE
The most basic wiring

### DIFF
--- a/src/main/java/com/karumi/reddo/config/TypesafeHubReddoConfig.java
+++ b/src/main/java/com/karumi/reddo/config/TypesafeHubReddoConfig.java
@@ -55,8 +55,8 @@ public class TypesafeHubReddoConfig implements ReddoConfig {
   @Override public List<ReddoTask> getTasks() {
     List<ReddoTask> tasks = new LinkedList<>();
     tasks.addAll(getMessagesTasks());
-//    tasks.addAll(getGitHubRepositoriesTasks());
-//    tasks.addAll(getGitHubUsersTasks());
+    tasks.addAll(getGitHubRepositoriesTasks());
+    tasks.addAll(getGitHubUsersTasks());
     return tasks;
   }
 
@@ -64,7 +64,7 @@ public class TypesafeHubReddoConfig implements ReddoConfig {
     int fps = getFramesPerSecond();
     switch (config.getString("output")) {
       case "led":
-        return new MatrixLedView(fps, getSocket());
+        return new MatrixLedView(fps, getConnectionRemoteIp(), getConnectionRemotePort());
       case "sysout":
       default:
         return new SysOutView();
@@ -106,14 +106,6 @@ public class TypesafeHubReddoConfig implements ReddoConfig {
 
   private int getFramesPerSecond() {
     return config.getInt("fps");
-  }
-
-  private Socket getSocket() {
-    try {
-      return new Socket(getConnectionRemoteIp(), getConnectionRemotePort());
-    } catch (IOException e) {
-      throw new ConfigException.Generic("Can not connect to " + getConnectionRemoteIp() + ":" + getConnectionRemotePort());
-    }
   }
 
   private String getConnectionRemoteIp() {

--- a/src/main/java/com/karumi/reddo/view/exceptions/MatrixLedViewException.java
+++ b/src/main/java/com/karumi/reddo/view/exceptions/MatrixLedViewException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.reddo.view.exceptions;
+
+public class MatrixLedViewException extends RuntimeException {
+  public MatrixLedViewException(String message) {
+    super("There was a problem with the LED matrix: " + message);
+  }
+}

--- a/src/main/resources/default-reddo-config.json
+++ b/src/main/resources/default-reddo-config.json
@@ -2,13 +2,13 @@
   "fps" : 60,
   "output" : "led",
   "connection" : {
-    "localPort": 9000,
     "remoteIp" : "127.0.0.1",
     "remotePort" : 9001
   },
   "gitHubOauthToken" : "",
   "messages" : [
-    "Welcome to the Karumi HQs ¯\\_(ツ)_/¯"
+    "Welcome to the Karumi HQs",
+    "Don't forget to take out the trash on thursdays!"
   ],
   "gitHubRepositories" : [
     "Karumi/Dexter",


### PR DESCRIPTION
This is the most simple implementation wiring together both, the led and the java client:

A python daemon waits for incoming connections and communicate with the java client using a minimalistic protocol: height (4 bytes) + width (4 bytes) + RGB data (from left to right, top to bottom, 4 bytes per pixel in format ARGB, alpha is ignored :rabbit: )
I'm not a pythonist so there might be some conventions I might be breaking ¯\_(ツ)_/¯

PD: I had to remove the _¯\_(ツ)_/¯_ guy because I've been unable to export the unicode character to a drawable image in Java, I think it has to do with the raspberry environment/fonts (I tried with several fonts and stuff, I just can't wrap my head about the issue, it displays just fine in the demo window!)

Enjoy!
