### PR TITLE
Clear some references to avoid memory leaks.

### DIFF
--- a/script/led_daemon/led_display.py
+++ b/script/led_daemon/led_display.py
@@ -23,3 +23,4 @@ class Display:
     def clean(self):
         self.canvas.Fill(0, 0, 0)
         self.canvas = self.matrix.SwapOnVSync(self.canvas)
+        self.canvas = None

--- a/script/led_daemon/render_task.py
+++ b/script/led_daemon/render_task.py
@@ -15,6 +15,7 @@ class RenderTask:
             display.render(subframe)
             self.sleep_until_next_frame(render_frame_start_time_ms)
         display.clean()
+        self.frame = None
 
     # This method makes the thread sleeps until the allocated time for each
     # frame is consumed.


### PR DESCRIPTION
Memory leak found and fixed \o/